### PR TITLE
Update Copulogram.py to newer versions of Pandas

### DIFF
--- a/copulogram/Copulogram.py
+++ b/copulogram/Copulogram.py
@@ -173,7 +173,7 @@ class Copulogram:
                                         common_norm=False, 
                                 )
                 # Ticker tuning 
-                xticks = np.linspace(xmins[j], xmaxs[j], 4)
+                xticks = np.linspace(xmins.iloc[j], xmaxs.iloc[j], 4)
                 ax.set_xticks(xticks)
                 ax.set_xticklabels(ax.get_xticks(), rotation=90)
                 ax.xaxis.set_major_formatter(ticker.StrMethodFormatter("{x:.3}"))
@@ -219,8 +219,8 @@ class Copulogram:
                     )
                     ax.collections[0].set_sizes([markersize])
                 # Ticker tuning
-                xticks = np.linspace(xmins[j], xmaxs[j], 4)
-                yticks = np.linspace(xmins[i], xmaxs[i], 4)
+                xticks = np.linspace(xmins.iloc[j], xmaxs.iloc[j], 4)
+                yticks = np.linspace(xmins.iloc[i], xmaxs.iloc[i], 4)
                 ax.set_xticks(xticks)
                 ax.set_yticks(yticks)
                 ax.set_xticklabels(ax.get_xticks(), rotation=90)


### PR DESCRIPTION
Fix the code to get rid of the following warning:

FutureWarning: `Series.__getitem__` treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
  `xticks = np.linspace(xmins[j], xmaxs[j], 4)`